### PR TITLE
Add note about ammonite await

### DIFF
--- a/concurrency/exercises-answers/crony-connect.sc
+++ b/concurrency/exercises-answers/crony-connect.sc
@@ -39,4 +39,10 @@ def getCronies(kingpin: Person): Future[Set[Person]] = {
   } yield cronies.toSet.filterNot(_ == kingpin)
 }
 
-Await.result(getCronies(Person("Ronald McDonald")), 10.seconds)
+// Ammonite doesn't like calling Await.result at the top level.
+// So to test run:
+//
+// amm -p cony-connect.sc
+//
+// In REPL:
+// Await.result(getCronies(Person("Ronald McDonald")), 10.seconds)

--- a/concurrency/exercises/crony-connect.sc
+++ b/concurrency/exercises/crony-connect.sc
@@ -25,4 +25,10 @@ case class Company(id: Int, name: String)
 // TASK
 def getCronies(kingpin: Person): Future[List[Person]] = ???
 
-Await.result(getCronies(Person("Ronald McDonald")), 10.seconds)
+// Ammonite doesn't like calling Await.result at the top level.
+// So to test run:
+//
+// amm -p cony-connect.sc
+//
+// In REPL:
+// Await.result(getCronies(Person("Ronald McDonald")), 10.seconds)


### PR DESCRIPTION
Ammonite doesn't like calling Await.result at the top level. If I call

```scala
 Await.result(getCronies(Person("Ronald McDonald")), 10.seconds)
```

at the end of the script, I get this:

```
java.lang.NoClassDefFoundError: Could not initialize class ammonite.$file.crony$minusconnect$
	at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:433)
	at scala.concurrent.BatchingExecutor$AbstractBatch.runN(BatchingExecutor.scala:134)
	at scala.concurrent.BatchingExecutor$AsyncBatch.apply(BatchingExecutor.scala:163)
	at scala.concurrent.BatchingExecutor$AsyncBatch.apply(BatchingExecutor.scala:146)
	at scala.concurrent.BlockContext$.usingBlockContext(BlockContext.scala:107)
	at scala.concurrent.BatchingExecutor$AsyncBatch.run(BatchingExecutor.scala:154)
	at java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1402)
	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
	at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)
java.util.concurrent.TimeoutException: Future timed out after [10 seconds]
  scala.concurrent.impl.Promise$DefaultPromise.tryAwait0(Promise.scala:212)
  scala.concurrent.impl.Promise$DefaultPromise.result(Promise.scala:225)
  scala.concurrent.Await$.$anonfun$result$1(package.scala:201)
  scala.concurrent.BlockContext$DefaultBlockContext$.blockOn(BlockContext.scala:62)
  scala.concurrent.Await$.result(package.scala:124)
  ammonite.$file.crony$minusconnect$App$.main(crony-connect.sc:44)
  ammonite.$file.crony$minusconnect$.<clinit>(crony-connect.sc:49)
```

I even get it if I do

```scala
object App {
  def main: Unit = {
    val cronies = Await.result(getCronies(Person("Ronald McDonald")), 10.seconds)
    println(s"Ronald's cronies: ${cronies}")
  }
}

App.main
```