### PR TITLE
provide execution context

### DIFF
--- a/concurrency/blocking.sc
+++ b/concurrency/blocking.sc
@@ -1,7 +1,6 @@
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, Future}
-import UserStore._
 
 object UserStore {
   case class User(name: String)
@@ -10,6 +9,8 @@ object UserStore {
 
   def fetch(id: String): Future[String] = Future.successful(s"Mr Test$id")
 }
+
+import UserStore._
 
 def fetchUserNameBlocking(id: String): String = {
   // blocks this thread until fetch completes

--- a/concurrency/flatMap.sc
+++ b/concurrency/flatMap.sc
@@ -1,6 +1,10 @@
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, Future}
+
+implicit def ec = ExecutionContext.fromExecutor(
+  new java.util.concurrent.ForkJoinPool(10)
+)
 
 def sleepyAdder(a: Int, b: Int): Future[Int] =
   Future {
@@ -36,3 +40,10 @@ def parallelAdder(): Unit = {
   val finalSum = Await.result(result, 10.seconds)
   println(s"Final sum: $finalSum")
 }
+
+sequentialAdder()
+
+println
+println
+
+parallelAdder()


### PR DESCRIPTION
Running in intellij we're getting threadpool errors:
`java.util.concurrent.RejectedExecutionException: Task java.util.concurrent.FutureTask@5d1e443e rejected from java.util.concurrent.ThreadPoolExecutor@181cc1f9[Terminated, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 48]`

Providing a custom `ExecutionContext` solves this (instead of using the default global `ExecutionContext`).
Here the implicit `ExecutionContext` is used to create the Future in `sleepyAdder`, and for each `flatMap` (which also creates a new Future)